### PR TITLE
dts: Provide analog configuration for each pin

### DIFF
--- a/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f0/stm32f030cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030cctx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f030f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030f4px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -76,6 +76,228 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f0/stm32f030rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030rctx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f038f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038f6px-pinctrl.dtsi
@@ -44,6 +44,64 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
@@ -48,6 +48,96 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -48,6 +48,80 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -48,6 +48,80 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,120 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -48,6 +48,104 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -52,6 +52,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -52,6 +52,164 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -76,6 +76,228 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -76,6 +76,228 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -76,6 +76,228 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -76,6 +76,228 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
@@ -52,6 +52,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -76,6 +76,224 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -76,6 +76,224 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
@@ -52,6 +52,120 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -48,6 +48,76 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
@@ -76,6 +76,356 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,356 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -76,6 +76,356 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,356 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -76,6 +76,352 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -76,6 +76,352 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,360 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -76,6 +76,360 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -76,6 +76,356 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -76,6 +76,356 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -76,6 +76,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -76,6 +76,456 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -76,6 +76,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -76,6 +76,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -76,6 +76,456 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -76,6 +76,456 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -92,6 +92,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -92,6 +92,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -92,6 +92,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -92,6 +92,156 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -132,6 +132,208 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -140,6 +140,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -132,6 +132,208 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -140,6 +140,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -160,6 +160,208 @@
 				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -92,6 +92,112 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -92,6 +92,112 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -172,6 +172,328 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -172,6 +172,328 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -172,6 +172,328 @@
 				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -192,6 +192,456 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -192,6 +192,456 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -192,6 +192,456 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -192,6 +192,456 @@
 				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32F1_PINMUX('F', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32F1_PINMUX('F', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32F1_PINMUX('F', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32F1_PINMUX('F', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32F1_PINMUX('F', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32F1_PINMUX('F', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32F1_PINMUX('F', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32F1_PINMUX('F', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32F1_PINMUX('F', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32F1_PINMUX('F', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32F1_PINMUX('F', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32F1_PINMUX('F', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32F1_PINMUX('G', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32F1_PINMUX('G', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32F1_PINMUX('G', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32F1_PINMUX('G', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32F1_PINMUX('G', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32F1_PINMUX('G', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32F1_PINMUX('G', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32F1_PINMUX('G', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32F1_PINMUX('G', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32F1_PINMUX('G', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32F1_PINMUX('G', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32F1_PINMUX('G', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32F1_PINMUX('G', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32F1_PINMUX('G', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32F1_PINMUX('G', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32F1_PINMUX('G', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -140,6 +140,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -140,6 +140,212 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -140,6 +140,328 @@
 				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32F1_PINMUX('A', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32F1_PINMUX('A', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32F1_PINMUX('A', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32F1_PINMUX('A', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32F1_PINMUX('A', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32F1_PINMUX('B', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32F1_PINMUX('C', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32F1_PINMUX('C', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32F1_PINMUX('C', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32F1_PINMUX('C', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32F1_PINMUX('C', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32F1_PINMUX('C', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32F1_PINMUX('C', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32F1_PINMUX('C', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32F1_PINMUX('C', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32F1_PINMUX('C', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32F1_PINMUX('D', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32F1_PINMUX('D', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32F1_PINMUX('D', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32F1_PINMUX('D', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32F1_PINMUX('D', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32F1_PINMUX('D', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32F1_PINMUX('D', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32F1_PINMUX('D', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32F1_PINMUX('D', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32F1_PINMUX('D', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32F1_PINMUX('D', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32F1_PINMUX('D', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32F1_PINMUX('E', 0, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32F1_PINMUX('E', 1, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32F1_PINMUX('E', 2, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32F1_PINMUX('E', 3, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32F1_PINMUX('E', 4, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32F1_PINMUX('E', 7, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, ANALOG, NO_REMAP)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32F1_PINMUX('E', 15, ANALOG, NO_REMAP)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -56,6 +56,156 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -56,6 +56,156 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -48,6 +48,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -44,6 +44,104 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -72,6 +72,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -56,6 +56,156 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -48,6 +48,156 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -56,6 +56,156 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -44,6 +44,104 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -72,6 +72,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -92,6 +92,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -96,6 +96,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -100,6 +100,356 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -104,6 +104,352 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -104,6 +104,352 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -96,6 +96,320 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -108,6 +108,468 @@
 				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -72,6 +72,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -72,6 +72,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -88,6 +88,160 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -48,6 +48,104 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -112,6 +112,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -116,6 +116,216 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -120,6 +120,212 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -212,6 +212,356 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -216,6 +216,352 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -216,6 +216,352 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -184,6 +184,320 @@
 				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -192,6 +192,320 @@
 				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -220,6 +220,468 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -56,6 +56,152 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -56,6 +56,152 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -44,6 +44,100 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -68,6 +68,152 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -72,6 +72,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -88,6 +88,160 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -48,6 +48,104 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -112,6 +112,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -68,6 +68,152 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -112,6 +112,212 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -208,6 +208,352 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -48,6 +48,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -48,6 +48,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -212,6 +212,348 @@
 				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can_rx_pa11: can_rx_pa11 {

--- a/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(b-c)yx-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)ux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401c(d-e)yx-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401ccfx-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -144,6 +144,296 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
@@ -52,6 +52,148 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa5: dac_out1_pa5 {

--- a/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa5: dac_out1_pa5 {

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa5: dac_out1_pa5 {

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa5: dac_out1_pa5 {

--- a/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
@@ -28,6 +28,100 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa5: dac_out1_pa5 {

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -76,6 +76,464 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -76,6 +76,464 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -76,6 +76,248 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -76,6 +76,464 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -76,6 +76,464 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -144,6 +144,296 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -172,6 +172,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -76,6 +76,248 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -76,6 +76,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -76,6 +76,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -76,6 +76,464 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -76,6 +76,464 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -188,6 +188,528 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -188,6 +188,528 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -188,6 +188,528 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -188,6 +188,528 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -152,6 +152,260 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -172,6 +172,208 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -172,6 +172,332 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -156,6 +156,292 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -156,6 +156,292 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -188,6 +188,432 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -188,6 +188,432 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -156,6 +156,292 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -188,6 +188,432 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -164,6 +164,208 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -204,6 +204,560 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -204,6 +204,560 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -172,6 +172,324 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -172,6 +172,324 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -204,6 +204,456 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -204,6 +204,456 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -204,6 +204,560 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -164,6 +164,208 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -204,6 +204,456 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -164,6 +164,208 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -204,6 +204,560 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -204,6 +204,560 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -172,6 +172,324 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -172,6 +172,324 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -204,6 +204,456 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -204,6 +204,456 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -204,6 +204,568 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -204,6 +204,680 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -172,6 +172,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -204,6 +204,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -148,6 +148,520 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -204,6 +204,532 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -204,6 +204,644 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,188 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -76,6 +76,120 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -52,6 +52,84 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,132 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -76,6 +76,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -76,6 +76,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -72,6 +72,120 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -76,6 +76,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -72,6 +72,120 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
@@ -88,6 +88,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
@@ -88,6 +88,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g050f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050f6px-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
@@ -88,6 +88,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
@@ -88,6 +88,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
@@ -72,6 +72,120 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
@@ -88,6 +88,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
@@ -88,6 +88,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
@@ -76,6 +76,124 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
@@ -72,6 +72,120 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
@@ -76,6 +76,136 @@
 				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -68,6 +68,188 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -56,6 +56,132 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -76,6 +76,252 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -52,6 +52,120 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -48,6 +48,120 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -52,6 +52,136 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -52,6 +52,136 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -52,6 +52,120 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -48,6 +48,120 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -52,6 +52,136 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -52,6 +52,136 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
@@ -68,6 +68,184 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
@@ -68,6 +68,184 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
@@ -52,6 +52,132 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
@@ -52,6 +52,132 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
@@ -52,6 +52,132 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
@@ -52,6 +52,132 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
@@ -76,6 +76,312 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,312 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
@@ -76,6 +76,200 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
@@ -76,6 +76,248 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
@@ -76,6 +76,248 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
@@ -68,6 +68,184 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -68,6 +68,192 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
@@ -68,6 +68,184 @@
 				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -52,6 +52,132 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -56,6 +56,136 @@
 				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -52,6 +52,132 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,312 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
@@ -76,6 +76,200 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
@@ -76,6 +76,248 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,256 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
@@ -76,6 +76,248 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,392 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -96,6 +96,176 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -96,6 +96,172 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -64,6 +64,112 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -64,6 +64,112 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -132,6 +132,272 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -132,6 +132,352 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -96,6 +96,176 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -96,6 +96,172 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -64,6 +64,112 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -64,6 +64,112 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -132,6 +132,272 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -132,6 +132,352 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -104,6 +104,160 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -108,6 +108,176 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -176,6 +176,272 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -180,6 +180,276 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -192,6 +192,436 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -192,6 +192,352 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -192,6 +192,352 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -192,6 +192,352 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -124,6 +124,160 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -128,6 +128,176 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -260,6 +260,272 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -272,6 +272,276 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -308,6 +308,416 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -308,6 +308,436 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -164,6 +164,216 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -124,6 +124,160 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -128,6 +128,176 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -260,6 +260,272 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -272,6 +272,276 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -308,6 +308,416 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -308,6 +308,436 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -164,6 +164,216 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -124,6 +124,160 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -128,6 +128,176 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -260,6 +260,272 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -272,6 +272,276 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -308,6 +308,416 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -308,6 +308,436 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -164,6 +164,216 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -124,6 +124,160 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -128,6 +128,176 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -260,6 +260,272 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -272,6 +272,276 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -308,6 +308,416 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -308,6 +308,436 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -164,6 +164,216 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -308,6 +308,352 @@
 				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -104,6 +104,160 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -108,6 +108,176 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -68,6 +68,112 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -176,6 +176,272 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -176,6 +176,272 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -192,6 +192,352 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -104,6 +104,160 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -108,6 +108,176 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -68,6 +68,112 @@
 				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -176,6 +176,272 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -176,6 +176,272 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -144,6 +144,216 @@
 				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -192,6 +192,352 @@
 				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -128,6 +128,176 @@
 				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -284,6 +284,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -284,6 +284,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -332,6 +332,508 @@
 				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -332,6 +332,508 @@
 				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -172,6 +172,192 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -172,6 +172,192 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -184,6 +184,316 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -184,6 +184,284 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -184,6 +184,316 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -184,6 +184,284 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -172,6 +172,276 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -228,6 +228,404 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -228,6 +228,404 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -332,6 +332,508 @@
 				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -284,6 +284,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -284,6 +284,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -332,6 +332,508 @@
 				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -172,6 +172,192 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -184,6 +184,316 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -184,6 +184,284 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -172,6 +172,276 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -228,6 +228,404 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -284,6 +284,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -284,6 +284,680 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -284,6 +284,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -284,6 +284,680 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -284,6 +284,680 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -284,6 +284,608 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -284,6 +284,608 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -228,6 +228,404 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -228,6 +228,404 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -284,6 +284,572 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -284,6 +284,572 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -224,6 +224,412 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -284,6 +284,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -284,6 +284,680 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -284,6 +284,568 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -184,6 +184,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -284,6 +284,608 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -348,6 +348,536 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -256,6 +256,492 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -228,6 +228,404 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -284,6 +284,572 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -256,6 +256,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -348,6 +348,696 @@
 				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -224,6 +224,412 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -220,6 +220,508 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -176,6 +176,568 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -220,6 +220,536 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -176,6 +176,568 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -176,6 +176,492 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -220,6 +220,696 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -176,6 +176,680 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -180,6 +180,356 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,204 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -152,6 +152,336 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -152,6 +152,316 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -152,6 +152,336 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -152,6 +152,288 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -176,6 +176,464 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -164,6 +164,404 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -220,6 +220,508 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -220,6 +220,536 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -176,6 +176,568 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -172,6 +172,204 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -152,6 +152,336 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -176,6 +176,464 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -220,6 +220,508 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -176,6 +176,568 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -220,6 +220,536 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -176,6 +176,568 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -176,6 +176,492 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -220,6 +220,696 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -176,6 +176,680 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -180,6 +180,356 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -172,6 +172,204 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -152,6 +152,336 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -152,6 +152,316 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -152,6 +152,336 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -152,6 +152,288 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -176,6 +176,464 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -164,6 +164,404 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l010f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010f4px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
@@ -28,6 +28,48 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
@@ -40,6 +40,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l021d4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021d4px-pinctrl.dtsi
@@ -28,6 +28,48 @@
 				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l021f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
@@ -40,6 +40,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa4: i2c1_scl_pa4 {

--- a/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,92 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
@@ -52,6 +52,88 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041f6px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041f6px-pinctrl.dtsi
@@ -48,6 +48,68 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
@@ -52,6 +52,92 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
@@ -52,6 +52,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -52,6 +52,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -52,6 +52,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -52,6 +52,116 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
@@ -64,6 +64,168 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -64,6 +64,168 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -64,6 +64,168 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073czyx-pinctrl.dtsi
@@ -64,6 +64,168 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l081czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081czux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l081kztx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kztx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l081kzux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kzux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -64,6 +64,168 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,108 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -52,6 +52,100 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -52,6 +52,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -76,6 +76,344 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6ux-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100c6uxa-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)tx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100r(8-b)txa-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)tx-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)txa-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)ux-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151c(6-8-b)uxa-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151cctx-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ccux-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hx-pinctrl.dtsi
@@ -88,6 +88,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)hxa-pinctrl.dtsi
@@ -88,6 +88,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)tx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151r(6-8-b)txa-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)hxa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)tx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151v(8-b)txa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)tx-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)txa-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)ux-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152c(6-8-b)uxa-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152cctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152cctx-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152ccux-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ccux-pinctrl.dtsi
@@ -68,6 +68,156 @@
 				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hx-pinctrl.dtsi
@@ -88,6 +88,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)hxa-pinctrl.dtsi
@@ -88,6 +88,208 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)tx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152r(6-8-b)txa-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)hxa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)tx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152v(8-b)txa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qchx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -124,6 +124,444 @@
 				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -92,6 +92,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -108,6 +108,340 @@
 				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zctx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -128,6 +128,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa4: dac_out1_pa4 {

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -84,6 +84,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -84,6 +84,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -84,6 +84,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -84,6 +84,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -84,6 +84,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -84,6 +84,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -84,6 +84,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -84,6 +84,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -84,6 +84,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -84,6 +84,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -124,6 +124,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -124,6 +124,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -84,6 +84,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -84,6 +84,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -84,6 +84,120 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -84,6 +84,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -84,6 +84,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -84,6 +84,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -84,6 +84,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -132,6 +132,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -84,6 +84,124 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -56,6 +56,164 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -56,6 +56,164 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -56,6 +56,164 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -72,6 +72,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -52,6 +52,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -76,6 +76,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -168,6 +168,444 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -156,6 +156,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -156,6 +156,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -188,6 +188,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -188,6 +188,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -156,6 +156,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -156,6 +156,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -156,6 +156,236 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -148,6 +148,228 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -156,6 +156,268 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -168,6 +168,444 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -156,6 +156,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -156,6 +156,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -188,6 +188,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -188,6 +188,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -188,6 +188,456 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -156,6 +156,236 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -156,6 +156,236 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -168,6 +168,444 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -156,6 +156,212 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -156,6 +156,336 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -188,6 +188,464 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -172,6 +172,552 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -172,6 +172,544 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -168,6 +168,448 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -168,6 +168,440 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -156,6 +156,216 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -148,6 +148,208 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -156,6 +156,340 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -156,6 +156,332 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -156,6 +156,332 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -148,6 +148,328 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -156,6 +156,368 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -188,6 +188,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -188,6 +188,460 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -172,6 +172,552 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -172,6 +172,544 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -168,6 +168,448 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -168,6 +168,440 @@
 				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -156,6 +156,216 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -148,6 +148,208 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -156,6 +156,340 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -156,6 +156,332 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -156,6 +156,332 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -148,6 +148,328 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -188,6 +188,468 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -188,6 +188,460 @@
 				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -140,6 +140,552 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -140,6 +140,544 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -140,6 +140,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -140,6 +140,440 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -140,6 +140,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -132,6 +132,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -140,6 +140,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -140,6 +140,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -140,6 +140,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -132,6 +132,328 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -140,6 +140,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -140,6 +140,460 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -140,6 +140,552 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -140,6 +140,544 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -140,6 +140,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -140,6 +140,440 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -140,6 +140,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -132,6 +132,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -140,6 +140,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -140,6 +140,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -140,6 +140,332 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -132,6 +132,328 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -140,6 +140,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -140,6 +140,460 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -76,6 +76,552 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -76,6 +76,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -76,6 +76,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -76,6 +76,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -76,6 +76,460 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -76,6 +76,552 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -76,6 +76,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -72,6 +72,532 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -72,6 +72,316 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -76,6 +76,456 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -72,6 +72,448 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -76,6 +76,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -76,6 +76,440 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -76,6 +76,552 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -76,6 +76,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -76,6 +76,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -76,6 +76,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -76,6 +76,552 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -76,6 +76,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -76,6 +76,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -72,6 +72,532 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -72,6 +72,316 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -76,6 +76,456 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -72,6 +72,448 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -76,6 +76,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* CAN_RX */
 
 			can1_rx_pa11: can1_rx_pa11 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -132,6 +132,252 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -132,6 +132,240 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -140,6 +140,432 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -140,6 +140,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -140,6 +140,440 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -140,6 +140,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -132,6 +132,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -124,6 +124,196 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -124,6 +124,324 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -140,6 +140,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -124,6 +124,452 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -140,6 +140,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -92,6 +92,160 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -92,6 +92,152 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -132,6 +132,252 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -132,6 +132,240 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -140,6 +140,448 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -140,6 +140,440 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -140,6 +140,432 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -140,6 +140,216 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -132,6 +132,208 @@
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -124,6 +124,196 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -140,6 +140,340 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -124,6 +124,324 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -140,6 +140,468 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -124,6 +124,452 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -192,6 +192,712 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pi12: analog_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, ANALOG)>;
+			};
+
+			analog_pi13: analog_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, ANALOG)>;
+			};
+
+			analog_pi14: analog_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, ANALOG)>;
+			};
+
+			analog_pi15: analog_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, ANALOG)>;
+			};
+
+			analog_pj0: analog_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, ANALOG)>;
+			};
+
+			analog_pj1: analog_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, ANALOG)>;
+			};
+
+			analog_pj2: analog_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, ANALOG)>;
+			};
+
+			analog_pj3: analog_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, ANALOG)>;
+			};
+
+			analog_pj4: analog_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, ANALOG)>;
+			};
+
+			analog_pj5: analog_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, ANALOG)>;
+			};
+
+			analog_pj6: analog_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, ANALOG)>;
+			};
+
+			analog_pj7: analog_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, ANALOG)>;
+			};
+
+			analog_pj8: analog_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, ANALOG)>;
+			};
+
+			analog_pj9: analog_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, ANALOG)>;
+			};
+
+			analog_pj10: analog_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, ANALOG)>;
+			};
+
+			analog_pj11: analog_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, ANALOG)>;
+			};
+
+			analog_pj12: analog_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, ANALOG)>;
+			};
+
+			analog_pj13: analog_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, ANALOG)>;
+			};
+
+			analog_pj14: analog_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, ANALOG)>;
+			};
+
+			analog_pj15: analog_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, ANALOG)>;
+			};
+
+			analog_pk0: analog_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, ANALOG)>;
+			};
+
+			analog_pk1: analog_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, ANALOG)>;
+			};
+
+			analog_pk2: analog_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, ANALOG)>;
+			};
+
+			analog_pk3: analog_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, ANALOG)>;
+			};
+
+			analog_pk4: analog_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, ANALOG)>;
+			};
+
+			analog_pk5: analog_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, ANALOG)>;
+			};
+
+			analog_pk6: analog_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, ANALOG)>;
+			};
+
+			analog_pk7: analog_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -192,6 +192,600 @@
 				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
+			analog_pi8: analog_pi8 {
+				pinmux = <STM32_PINMUX('I', 8, ANALOG)>;
+			};
+
+			analog_pi9: analog_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, ANALOG)>;
+			};
+
+			analog_pi10: analog_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, ANALOG)>;
+			};
+
+			analog_pi11: analog_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, ANALOG)>;
+			};
+
+			analog_pz0: analog_pz0 {
+				pinmux = <STM32_PINMUX('Z', 0, ANALOG)>;
+			};
+
+			analog_pz1: analog_pz1 {
+				pinmux = <STM32_PINMUX('Z', 1, ANALOG)>;
+			};
+
+			analog_pz2: analog_pz2 {
+				pinmux = <STM32_PINMUX('Z', 2, ANALOG)>;
+			};
+
+			analog_pz3: analog_pz3 {
+				pinmux = <STM32_PINMUX('Z', 3, ANALOG)>;
+			};
+
+			analog_pz4: analog_pz4 {
+				pinmux = <STM32_PINMUX('Z', 4, ANALOG)>;
+			};
+
+			analog_pz5: analog_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, ANALOG)>;
+			};
+
+			analog_pz6: analog_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, ANALOG)>;
+			};
+
+			analog_pz7: analog_pz7 {
+				pinmux = <STM32_PINMUX('Z', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -172,6 +172,400 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -156,6 +156,552 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -156,6 +156,540 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -156,6 +156,552 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -156,6 +156,540 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -80,6 +80,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -76,6 +76,140 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -80,6 +80,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -76,6 +76,140 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -80,6 +80,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -76,6 +76,140 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -80,6 +80,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -76,6 +76,140 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -120,6 +120,284 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -120,6 +120,284 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -156,6 +156,448 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -156,6 +156,432 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -156,6 +156,448 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -156,6 +156,432 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -128,6 +128,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -112,6 +112,196 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -128,6 +128,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -112,6 +112,196 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -140,6 +140,336 @@
 				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -124,6 +124,324 @@
 				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -140,6 +140,336 @@
 				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -124,6 +124,324 @@
 				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -156,6 +156,464 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -140,6 +140,452 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -156,6 +156,464 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -140,6 +140,452 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -156,6 +156,552 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -156,6 +156,540 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph2: analog_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
+			analog_ph4: analog_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, ANALOG)>;
+			};
+
+			analog_ph5: analog_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, ANALOG)>;
+			};
+
+			analog_ph6: analog_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, ANALOG)>;
+			};
+
+			analog_ph7: analog_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, ANALOG)>;
+			};
+
+			analog_ph8: analog_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, ANALOG)>;
+			};
+
+			analog_ph9: analog_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, ANALOG)>;
+			};
+
+			analog_ph10: analog_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, ANALOG)>;
+			};
+
+			analog_ph11: analog_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, ANALOG)>;
+			};
+
+			analog_ph12: analog_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, ANALOG)>;
+			};
+
+			analog_ph13: analog_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, ANALOG)>;
+			};
+
+			analog_ph14: analog_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, ANALOG)>;
+			};
+
+			analog_ph15: analog_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, ANALOG)>;
+			};
+
+			analog_pi0: analog_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, ANALOG)>;
+			};
+
+			analog_pi1: analog_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, ANALOG)>;
+			};
+
+			analog_pi2: analog_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, ANALOG)>;
+			};
+
+			analog_pi3: analog_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, ANALOG)>;
+			};
+
+			analog_pi4: analog_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, ANALOG)>;
+			};
+
+			analog_pi5: analog_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, ANALOG)>;
+			};
+
+			analog_pi6: analog_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, ANALOG)>;
+			};
+
+			analog_pi7: analog_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -80,6 +80,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -76,6 +76,140 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -80,6 +80,156 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -76,6 +76,140 @@
 				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -120,6 +120,284 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585qeixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qeixq-pinctrl.dtsi
@@ -156,6 +156,432 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -156,6 +156,448 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -128,6 +128,212 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -112,6 +112,196 @@
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -140,6 +140,336 @@
 				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -124,6 +124,324 @@
 				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585zetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zetxq-pinctrl.dtsi
@@ -140,6 +140,452 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -156,6 +156,464 @@
 				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_pe5: analog_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, ANALOG)>;
+			};
+
+			analog_pe6: analog_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, ANALOG)>;
+			};
+
+			analog_pe7: analog_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, ANALOG)>;
+			};
+
+			analog_pe8: analog_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, ANALOG)>;
+			};
+
+			analog_pe9: analog_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, ANALOG)>;
+			};
+
+			analog_pe10: analog_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, ANALOG)>;
+			};
+
+			analog_pe11: analog_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, ANALOG)>;
+			};
+
+			analog_pe12: analog_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, ANALOG)>;
+			};
+
+			analog_pe13: analog_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, ANALOG)>;
+			};
+
+			analog_pe14: analog_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, ANALOG)>;
+			};
+
+			analog_pe15: analog_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, ANALOG)>;
+			};
+
+			analog_pf0: analog_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, ANALOG)>;
+			};
+
+			analog_pf1: analog_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, ANALOG)>;
+			};
+
+			analog_pf2: analog_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+			};
+
+			analog_pf3: analog_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+			};
+
+			analog_pf4: analog_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, ANALOG)>;
+			};
+
+			analog_pf5: analog_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, ANALOG)>;
+			};
+
+			analog_pf6: analog_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
+			};
+
+			analog_pf7: analog_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, ANALOG)>;
+			};
+
+			analog_pf8: analog_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, ANALOG)>;
+			};
+
+			analog_pf9: analog_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, ANALOG)>;
+			};
+
+			analog_pf10: analog_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, ANALOG)>;
+			};
+
+			analog_pf11: analog_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, ANALOG)>;
+			};
+
+			analog_pf12: analog_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			analog_pf13: analog_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, ANALOG)>;
+			};
+
+			analog_pf14: analog_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, ANALOG)>;
+			};
+
+			analog_pf15: analog_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, ANALOG)>;
+			};
+
+			analog_pg0: analog_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, ANALOG)>;
+			};
+
+			analog_pg1: analog_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, ANALOG)>;
+			};
+
+			analog_pg2: analog_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, ANALOG)>;
+			};
+
+			analog_pg3: analog_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, ANALOG)>;
+			};
+
+			analog_pg4: analog_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, ANALOG)>;
+			};
+
+			analog_pg5: analog_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, ANALOG)>;
+			};
+
+			analog_pg6: analog_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, ANALOG)>;
+			};
+
+			analog_pg7: analog_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, ANALOG)>;
+			};
+
+			analog_pg8: analog_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, ANALOG)>;
+			};
+
+			analog_pg9: analog_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, ANALOG)>;
+			};
+
+			analog_pg10: analog_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, ANALOG)>;
+			};
+
+			analog_pg11: analog_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, ANALOG)>;
+			};
+
+			analog_pg12: analog_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, ANALOG)>;
+			};
+
+			analog_pg13: analog_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, ANALOG)>;
+			};
+
+			analog_pg14: analog_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, ANALOG)>;
+			};
+
+			analog_pg15: analog_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac1_out1_pa4: dac1_out1_pa4 {

--- a/dts/st/wb/stm32wb10ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb10ccux-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb15ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccux-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb15ccuxe-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccuxe-pinctrl.dtsi
@@ -52,6 +52,152 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb15ccyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccyx-pinctrl.dtsi
@@ -52,6 +52,112 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -52,6 +52,128 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -76,6 +76,204 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -76,6 +76,204 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -76,6 +76,204 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -76,6 +76,296 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -76,6 +76,280 @@
 				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc7: analog_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, ANALOG)>;
+			};
+
+			analog_pc8: analog_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, ANALOG)>;
+			};
+
+			analog_pc9: analog_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, ANALOG)>;
+			};
+
+			analog_pc10: analog_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, ANALOG)>;
+			};
+
+			analog_pc11: analog_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, ANALOG)>;
+			};
+
+			analog_pc12: analog_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pd0: analog_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			analog_pd1: analog_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, ANALOG)>;
+			};
+
+			analog_pd2: analog_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
+			analog_pd3: analog_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, ANALOG)>;
+			};
+
+			analog_pd4: analog_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, ANALOG)>;
+			};
+
+			analog_pd5: analog_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, ANALOG)>;
+			};
+
+			analog_pd6: analog_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, ANALOG)>;
+			};
+
+			analog_pd7: analog_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, ANALOG)>;
+			};
+
+			analog_pd8: analog_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, ANALOG)>;
+			};
+
+			analog_pd9: analog_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, ANALOG)>;
+			};
+
+			analog_pd10: analog_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, ANALOG)>;
+			};
+
+			analog_pd11: analog_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, ANALOG)>;
+			};
+
+			analog_pd12: analog_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+			};
+
+			analog_pd13: analog_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, ANALOG)>;
+			};
+
+			analog_pd14: analog_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, ANALOG)>;
+			};
+
+			analog_pd15: analog_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+			};
+
+			analog_pe0: analog_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, ANALOG)>;
+			};
+
+			analog_pe1: analog_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, ANALOG)>;
+			};
+
+			analog_pe2: analog_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, ANALOG)>;
+			};
+
+			analog_pe3: analog_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, ANALOG)>;
+			};
+
+			analog_pe4: analog_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, ANALOG)>;
+			};
+
+			analog_ph0: analog_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, ANALOG)>;
+			};
+
+			analog_ph1: analog_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa9: i2c1_scl_pa9 {

--- a/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wl55ucyx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ucyx-pinctrl.dtsi
@@ -44,6 +44,96 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
@@ -48,6 +48,124 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
@@ -60,6 +60,180 @@
 				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb1: analog_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, ANALOG)>;
+			};
+
+			analog_pb2: analog_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pb5: analog_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, ANALOG)>;
+			};
+
+			analog_pb6: analog_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
+			analog_pb7: analog_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, ANALOG)>;
+			};
+
+			analog_pb8: analog_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, ANALOG)>;
+			};
+
+			analog_pb9: analog_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, ANALOG)>;
+			};
+
+			analog_pb10: analog_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, ANALOG)>;
+			};
+
+			analog_pb11: analog_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, ANALOG)>;
+			};
+
+			analog_pb12: analog_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, ANALOG)>;
+			};
+
+			analog_pb13: analog_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, ANALOG)>;
+			};
+
+			analog_pb14: analog_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, ANALOG)>;
+			};
+
+			analog_pb15: analog_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			analog_pc0: analog_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, ANALOG)>;
+			};
+
+			analog_pc1: analog_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			analog_pc2: analog_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			analog_pc4: analog_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
+			};
+
+			analog_pc5: analog_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, ANALOG)>;
+			};
+
+			analog_pc6: analog_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, ANALOG)>;
+			};
+
+			analog_pc13: analog_pc13 {
+				pinmux = <STM32_PINMUX('C', 13, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5u8yx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5u8yx-pinctrl.dtsi
@@ -44,6 +44,96 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/dts/st/wl/stm32wle5ubyx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ubyx-pinctrl.dtsi
@@ -44,6 +44,96 @@
 				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
 			};
 
+			/* Analog */
+
+			analog_pa0: analog_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			analog_pa2: analog_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, ANALOG)>;
+			};
+
+			analog_pa3: analog_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, ANALOG)>;
+			};
+
+			analog_pa4: analog_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
+			};
+
+			analog_pa5: analog_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
+			};
+
+			analog_pa6: analog_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
+			};
+
+			analog_pa7: analog_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, ANALOG)>;
+			};
+
+			analog_pa8: analog_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			analog_pa9: analog_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
+			};
+
+			analog_pa10: analog_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
+			};
+
+			analog_pa11: analog_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, ANALOG)>;
+			};
+
+			analog_pa12: analog_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, ANALOG)>;
+			};
+
+			analog_pa13: analog_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, ANALOG)>;
+			};
+
+			analog_pa14: analog_pa14 {
+				pinmux = <STM32_PINMUX('A', 14, ANALOG)>;
+			};
+
+			analog_pa15: analog_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			analog_pb0: analog_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, ANALOG)>;
+			};
+
+			analog_pb3: analog_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, ANALOG)>;
+			};
+
+			analog_pb4: analog_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			analog_pc14: analog_pc14 {
+				pinmux = <STM32_PINMUX('C', 14, ANALOG)>;
+			};
+
+			analog_pc15: analog_pc15 {
+				pinmux = <STM32_PINMUX('C', 15, ANALOG)>;
+			};
+
+			analog_ph3: analog_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, ANALOG)>;
+			};
+
 			/* DAC_OUT */
 
 			dac_out1_pa10: dac_out1_pa10 {

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -185,12 +185,10 @@ def format_remap(remap):
         DT remap definition.
     """
 
-    if remap == 0:
+    if remap == 0 or remap is None:
         return "NO_REMAP"
-    elif remap is not None:
+    else:
         return remap
-
-    raise ValueError(f"Unsupported remap: {remap}")
 
 
 def get_gpio_ip_afs(data_path):
@@ -414,6 +412,8 @@ def get_mcu_signals(data_path, gpio_ip_afs):
             # process all pin signals
             for signal in pin.findall(NS + "Signal"):
                 if signal.get("Name") == "GPIO":
+                    if signal.get("IOModes") and "Analog" in signal.get("IOModes"):
+                        pin_signals.append({"name": "ANALOG", "af": None})
                     continue
 
                 signal_name = signal.get("Name")

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -10,6 +10,8 @@
 #     STM32 xml database pin configuration names. The regular expression should
 #     be as precise as possible. Note that it needs to be escaped here in the
 #     configuration file.
+#     Note: Specific "ANALOG" value allows generation of analog pins
+#     configuration
 #
 #   - mode (optional): Mode setting (analog, alternate). Mode needs to
 #     be set according to the following rules:
@@ -33,6 +35,10 @@
 #
 
 ---
+- name: Analog
+  match: "ANALOG"
+  mode: analog
+
 - name: ADC_IN / ADC_INN / ADC_INP
   match: "^ADC(?:\\d+)?_IN[NP]?\\d+$"
 

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -10,6 +10,8 @@
 #     STM32 xml database pin configuration names. The regular expression should
 #     be as precise as possible. Note that it needs to be escaped here in the
 #     configuration file.
+#     Note: Specific "ANALOG" value allows generation of analog pins
+#     configuration
 #
 #   - mode (mandatory): Mode setting (analog, alternate, input). Mode needs to
 #     be set according to the following rules:
@@ -34,6 +36,10 @@
 #
 
 ---
+- name: Analog
+  match: "ANALOG"
+  mode: analog
+
 - name: ADC_IN
   match: "^ADC\\d+_IN\\d+$"
   mode: analog

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -146,9 +146,7 @@ def test_format_remap():
 
     assert format_remap("UART1_REMAP1") == "UART1_REMAP1"
     assert format_remap(0) == "NO_REMAP"
-
-    with pytest.raises(ValueError):
-        format_remap(None)
+    assert format_remap(None) == "NO_REMAP"
 
 
 def test_get_gpio_ip_afs(pindata):


### PR DESCRIPTION
Update generation script to provide analog configuration for each pin.
This configuration could be used as low power pin configuration, when possible.